### PR TITLE
Set up a weekly inspection of 3rd party dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: maven
     directory: "/"
     schedule:
-      interval:
-        cron: "14 3 * * 3"
+      interval: "weekly"
+      day: "wednesday"
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval:
-        cron: "14 3 * * 3"
+      interval: "weekly"
+      day: "wednesday"
     open-pull-requests-limit: 10
 


### PR DESCRIPTION
This includes compile-time dependencies, runtime dependencies and build tools.

Fixes #43