### PR TITLE
fix: corrected 'runime' to 'runtime' in Maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runime}</jacoco.agent.path>
+            <jacoco.agent.path>${org.jacoco:org.jacoco.agent:jar:runtime}</jacoco.agent.path>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR fixes Issue #97 by correcting the typo 'runime' to 'runtime' in the Maven configuration file (pom.xml). 
This ensures proper execution of the Jacoco agent during runtime.
