### PR TITLE
Setup JReleaser early-access flow and release docs (fixes #44)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -298,9 +298,13 @@ If you do not have musl and `libz.a` installed, you can use the profile `'-Pnati
 
 == Further reading
 
-* https://jqno.nl/post/2024/08/24/why-are-there-no-decent-code-formatters-for-java/[Why are there no decent code formatters for Java?] – by Jan Ouwens.
+* https://jqno.nl/post/2024/08/24/why-are-there-no-decent-code-formatters-for-Java/[Why are there no decent code formatters for Java?] – by Jan Ouwens.
 * link:++https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Fcore%2Fformatter%2FDefaultCodeFormatterConstants.html++[Class DefaultCodeFormatterConstants] – the reference for the JDT code formatter config.
 * https://github.com/diffplug/spotless/tree/main/plugin-maven#eclipse-jdt[Spotless Maven Plugin JDT setup] – the reference.
+
+== Releasing
+
+See link:RELEASING.adoc[RELEASING.adoc] for step-by-step instructions for Early Access builds and full releases with JReleaser.
 
 == FAQ
 

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0 OR EUPL-1.2
+= Releasing jfmt
+
+This document explains how maintainers can publish Early Access builds and perform full releases using JReleaser.
+
+== Overview
+
+jfmt uses:
+
+- GitHub Actions for CI and packaging native binaries
+- JReleaser for assembling and publishing release artifacts
+- A repository-wide configuration file: `jreleaser.yml`
+
+There are two paths:
+
+- Early Access (pre-release) builds on pushes to `main`
+- Full releases (to be refined in a dedicated follow-up issue)
+
+== Early Access (pre-release)
+
+The workflow `Publish Early Access builds` combines two jobs:
+
+. Build native binaries per target platform via the reusable workflow `./.github/workflows/build-native.yml`.
+. Collect those artifacts and publish a pre-release with `jreleaser:full-release`.
+
+Secrets:
+
+- The build job inherits repository secrets (`secrets: inherit`) so it can access the MUSL toolchain credentials.
+- The release job uses `JRELEASER_GITHUB_TOKEN` set from the `GH_PAT` secret for publishing the pre-release.
+
+Manual verification (optional):
+
+[source,shell]
+----
+# Show the effective JReleaser config (no network/publish)
+./mvnw -Prelease jreleaser:config
+
+# Dry-run a full release locally (no publish)
+./mvnw -Prelease jreleaser:full-release -Ddryrun
+----
+
+== Full release (follow-up)
+
+An additional workflow (based on `mcs/.github/workflows/release.yml`) can be added in a separate issue to cut full releases.
+It will likely:
+
+- Build artifacts (or reuse those from early-access)
+- Run `jreleaser:full-release` with appropriate configuration
+- Tag and publish a non-prerelease on GitHub
+
+== Where things live
+
+- JReleaser config: `jreleaser.yml`
+- Root POM release profile: `-Prelease` with `jreleaser-maven-plugin`
+- Reusable native build workflow: `./.github/workflows/build-native.yml`
+- Early Access workflow: `./.github/workflows/early-access.yml`
+
+== Notes
+
+- The Java archive (JAR) distribution is taken directly from `cli/target/jfmt-${project.version}.jar`.
+- Native binary archives are collected from the `artifacts` directory prepared by the early-access workflow.
+- Formatting: run `./mvnw spotless:apply` before committing changes to POMs or XML files.

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -40,7 +40,9 @@ distributions:
     stereotype: CLI
     type: JAVA_BINARY
     artifacts:
-      - path: ./cli/target/jreleaser/assemble/jfmt/java-archive/jfmt-{{projectVersion}}.jar
+      # Ship the plain runnable JAR from the CLI module
+      # This JAR is produced by Maven during the regular build (no JReleaser assemble step required)
+      - path: ./cli/target/jfmt-{{projectVersion}}.jar
   jfmt:
     stereotype: CLI
     type: BINARY

--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,19 @@
           <plugin>
             <groupId>org.jreleaser</groupId>
             <artifactId>jreleaser-maven-plugin</artifactId>
+            <!--
+              Running a full release:
+              Use `-Prelease jreleaser:full-release` to perform a release via GitHub Actions or locally.
+              This profile points JReleaser to the repository-wide `jreleaser.yml`.
+
+              In CI, the early-access workflow builds native binaries first
+              (via `.github/workflows/build-native.yml`) and then runs
+              `jreleaser:full-release` with `-DartifactsDir=...` to publish them.
+
+              Locally you can test the configuration with:
+              `./mvnw -Prelease jreleaser:config` (dry run) or
+              `./mvnw -Prelease jreleaser:full-release -Ddryrun`.
+            -->
             <configuration>
               <configFile>${maven.multiModuleProjectDirectory}/jreleaser.yml</configFile>
             </configuration>


### PR DESCRIPTION
- Verify and retain early-access workflow that reuses `build-native.yml` with `secrets: inherit`
- Adjust `jreleaser.yml` JAVA_BINARY distribution to publish CLI JAR directly
- Add release profile documentation in root `pom.xml`
- Add `RELEASING.adoc` with early-access instructions and local dry-run commands
- Link the new docs from `README.adoc`

Follow-up suggested: consolidate JReleaser config fully into `jreleaser.yml` and remove duplicated plugin execution in `cli/pom.xml` (kept as-is to avoid affecting existing integration tests).
