### PR TITLE
[#148] release: fix github release workflows

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -64,6 +64,9 @@ jobs:
         run: |
           ./mvnw \
             --batch-mode \
+            --strict-checksum \
+            --errors \
+            --non-recursive \
             -Prelease \
             -DartifactsDir=artifacts \
             jreleaser:full-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,8 +164,12 @@ jobs:
       - name: Release with JReleaser
         run: |
           ./mvnw \
-            --batch-mode --strict-checksum --errors \
-            -Prelease -DartifactsDir=artifacts \
+            --batch-mode \
+            --strict-checksum \
+            --errors \
+            --non-recursive \
+            -Prelease \
+            -DartifactsDir=artifacts \
             jreleaser:full-release
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -121,6 +121,7 @@ The release process uses the following Maven goals:
   - Uploads all distribution artifacts
   - Generates changelog from conventional commits
   - Executed in the early-access workflow's release job
+  - Must be run with `-N` and/or `-pl .`, so it only executes on the root project
 
 [TIP]
 ====


### PR DESCRIPTION
* will execute jreleaser only on the root project now

Fixes: #148
Refs: #148, #44, https://github.com/jreleaser/jreleaser/issues/1998
