### PR TITLE
fix: disable GraalVM metadata repository to support native-maven-plug…

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -346,6 +346,11 @@
               <imageName>${project.artifactId}-${project.version}</imageName>
               <agentResourceDirectory>${project.basedir}/src/main/graalvm-native</agentResourceDirectory>
 
+              <!-- Disable metadata repository since we use custom metadata -->
+              <metadataRepository>
+                <enabled>false</enabled>
+              </metadataRepository>
+
               <jvmArgs>
                 <jvmArg>-Duser.language=en</jvmArg>
                 <jvmArg>-Duser.country=US</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jacoco.version>0.8.15</jacoco.version>
 
     <!-- plugins -->
-    <native.maven.plugin.version>0.11.3</native.maven.plugin.version>
+    <native.maven.plugin.version>1.1.2</native.maven.plugin.version>
 
     <!-- 3rd party plugins -->
     <exec.plugin.version>3.6.3</exec.plugin.version>


### PR DESCRIPTION
…in 1.1.2

The plugin upgrade from 0.11.3 to 1.1.2 introduced schema validation for the reachability metadata repository. Since this project uses custom metadata in src/main/graalvm-native/resource-config.json and does not rely on the central repository, we disable it to avoid validation errors with GraalVM 25.0.2.

This change allows successful native image compilation on local development machines. The GitHub Actions musl/static build failure is unrelated to this plugin upgrade and requires separate investigation of the musl toolchain setup.