### PR TITLE
fix: Add all charsets to Windows executable

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -351,6 +351,10 @@
                 <enabled>false</enabled>
               </metadataRepository>
 
+              <buildArgs>
+                <buildArg>-H:+AddAllCharsets</buildArg>
+              </buildArgs>
+
               <jvmArgs>
                 <jvmArg>-Duser.language=en</jvmArg>
                 <jvmArg>-Duser.country=US</jvmArg>


### PR DESCRIPTION
This might fix the UnsupportedCharsetException with Cp1252 on Windows (#190).

Documentation says adding `-H:+AddAllCharsets` would increase the size of native image, but I haven't observed that. So either I'm doing something wrong, or this fix is incomplete.

