### PR TITLE
fix: make release dry-run checks executable

### DIFF
--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -199,7 +199,7 @@ The script runs maven-release-plugin and JReleaser in dry-run mode without makin
 **Problem:** "Artifacts not found"
 
 * Verify artifacts were downloaded to `./artifacts/`
-* Check artifact naming matches pattern in `jreleaser.yml`
+* Check artifact naming matches pattern in `jreleaser.toml`
 
 **Problem:** "GitHub API rate limit exceeded"
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -397,7 +397,7 @@
                        - jfmt-0.1.0-SNAPSHOT-osx-aarch_64.zip
                        - jfmt-0.1.0-SNAPSHOT-windows-x86_64.zip
                        
-                       This naming matches the expectations in jreleaser.yml distributions.
+                       This naming matches the expectations in jreleaser.toml distributions.
                   -->
                   <finalName>${project.artifactId}-${project.version}-${nisse.os.classifier}</finalName>
                   <descriptors>

--- a/test-release.sh
+++ b/test-release.sh
@@ -142,7 +142,7 @@ test_release_prepare_dry_run() {
     echo "This will simulate the release without making changes..."
     echo ""
     
-    ./mvnw release:prepare -DdryRun=true -DskipTests=true 2>&1 | tee /tmp/release-prepare-dry-run.log || {
+    ./mvnw -B release:prepare -DdryRun=true -DskipTests=true 2>&1 | tee /tmp/release-prepare-dry-run.log || {
         print_error "release:prepare dry-run failed"
         echo "Check /tmp/release-prepare-dry-run.log for details"
         exit 1

--- a/test-release.sh
+++ b/test-release.sh
@@ -127,7 +127,7 @@ check_maven_release_plugin() {
 }
 
 check_scm_configuration() {
-    if ./mvnw help:effective-pom -q | grep -A 5 "<scm>" | grep -q "<tag>"; then
+    if ./mvnw help:effective-pom | grep -A 5 "<scm>" | grep "<tag>" > /dev/null; then
         print_success "SCM tag configuration found"
         return 0
     fi

--- a/test-release.sh
+++ b/test-release.sh
@@ -235,9 +235,9 @@ check_jreleaser_github_token() {
     return 0
 }
 
-check_jreleaser_yml_exists() {
-    [ -f "jreleaser.yml" ] && return 0
-    print_error "jreleaser.yml not found"
+check_jreleaser_toml_exists() {
+    [ -f "jreleaser.toml" ] && return 0
+    print_error "jreleaser.toml not found"
     exit 1
 }
 
@@ -309,8 +309,8 @@ test_jreleaser_phase() {
     
     check_jreleaser_github_token
     
-    check_jreleaser_yml_exists
-    print_success "jreleaser.yml exists"
+    check_jreleaser_toml_exists
+    print_success "jreleaser.toml exists"
     
     test_jreleaser_configuration
     test_jreleaser_with_mock_artifacts

--- a/test-release.sh
+++ b/test-release.sh
@@ -121,7 +121,7 @@ check_prerequisites() {
 }
 
 check_maven_release_plugin() {
-    ./mvnw help:effective-pom -q | grep -q "maven-release-plugin" && return 0
+    ./mvnw help:effective-pom | grep -F "maven-release-plugin" > /dev/null && return 0
     print_error "maven-release-plugin not found in POM"
     exit 1
 }


### PR DESCRIPTION
Fixes #244.

- Detect the Maven release plugin from the effective POM without suppressing its output or triggering a `pipefail` SIGPIPE.
- Run `release:prepare` in batch mode for non-interactive dry runs.
- Align JReleaser validation and documentation with `jreleaser.toml`.